### PR TITLE
Allow demo env to be specified in URL params

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -87,7 +87,12 @@ function randomizeGame() {
 document.addEventListener('DOMContentLoaded', () => {
     initializeGames();
     const demoGame = document.querySelector('.featured-game');
+
     if (demoGame) {
-        randomizeGame();
+        // Load specific env if specified in URL params
+        const env = new URLSearchParams(window.location.search).get("env");
+
+        if (env != null && env in games) loadGame(games[env]);
+        else randomizeGame();
     }
 });


### PR DESCRIPTION
Allow the desired demo environment to be specified in the URL. This is helpful when trying to show someone a specific env.

For example, `puffer.ai/ocean.html?env=drone` will display the drone env when the page loads. If the env specified does not exist (or one is not provided) then we default to the behaviour of choosing a random demo.