### PR TITLE
More improvements

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -15,6 +15,7 @@
 
     <main class="content">
         <nav class="nav-box">
+            <p>On this page</p>
             <ul>
                 <li><a href="#post-12">PufferLib 3.0: Better Reinforcement Learning at 4M sps</a></li>
                 <li><a href="#post-11">Puffing Up PPO</a></li>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -9,6 +9,7 @@
 <body>
     <main class="content">
         <nav class="nav-box">
+            <p>On this page</p>
             <ul>
                 <li><a href="#post-1">Installation</a></li>
                 <li><a href="#post-2">Cheat Sheet</a></li>
@@ -176,7 +177,7 @@ env.done                                                          # True if all 
 
                 <h2>Emulation</h2>
                 <p>Complex environments may have heirarchical observations and actions, variable numbers of agents, and other quirks that make them difficult to work with and incompatible with standard reinforcement learning libraries. This was the initial motivation for PufferLib. The idea is to make every environment <i>emulate</i> the structure of simpler environments that most original RL tooling was written for. We flatten Gym/Gymnasium/PettingZoo spaces in our wrappers and unflatten them just in time for the model forward pass. This means you don't have to keep track of structured data during vectorization, in your experience buffers, or anywhere else, allowing for simpler and faster code. We also apply extra compatibility checks and pad multiagent environments to a fixed agent count. Under the hood, our wrappers maintain the Gym/Gymnasium/PettingZoo API using a stricter subset of available spaces, so you can still use them with other libraries outside of PufferLib.</p>
- 
+
                 <h2>Vectorization</h2>
                 <p>In RL, vectorization refers to the process of simulating multiple copies of an environment in parallel. Our Multiprocessing backend is fast -- much faster than Gymnasium's in most cases. Atari runs 50-60% faster synchronous and 5x faster async by our latest benchmark, and some environments like NetHack can be 10x faster even synchronous, with no API changes. Our vectorization works on almost any Gym/Gymnasium/PettingZoo environment after applying our 1-line emulation wrapper. PufferLib outperforms other vectorization implementations using the following optimizations:</p>
             <ul>

--- a/docs/header.html
+++ b/docs/header.html
@@ -157,7 +157,7 @@
                             <img src="https://img.shields.io/github/stars/pufferai/pufferlib?labelColor=999999&color=66dcdc&cacheSeconds=100000" alt="GitHub Stars">
                         </a>
                         <a href="https://discord.gg/puffer" target="_blank" rel="noopener noreferrer">
-                            <img alt="Discord" src="https://img.shields.io/discord/1019421966429593712?style=plastic&label=Discord&color=7289da">
+                            <img alt="Discord" src="https://img.shields.io/discord/1019421966429593712?label=Discord&color=5865F2">
                         </a>
                         <a href="https://twitter.com/jsuarez5341" target="_blank" rel="noopener noreferrer">
                             <img src="https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20@jsuarez5341" alt="Twitter Follow">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -137,17 +137,26 @@ a:hover {
 .nav-box {
     background: var(--background);
     padding: 1rem;
-    margin-bottom: 2rem;
     border-radius: 8px;
-}
+    max-width: 20rem;
+    float: right;
 
-.nav-box ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
+    * {
+        display: flex;
+    }
+    ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        flex-direction: column;
+    }
+    p {
+        font-weight: 600;
+        margin-block: 0 0.5rem;
+    }
+    a {
+        padding-block: 0.5rem;
+    }
 }
 
 /* Reusable content container */
@@ -171,13 +180,6 @@ a:hover {
 .image-container figcaption {
     color: var(--highlight);
     margin-top: 0.5rem;
-}
-
-/* Basic responsive rules */
-@media (max-width: 768px) {
-    .nav-box ul {
-        flex-direction: column;
-    }
 }
 
 pre {


### PR DESCRIPTION
After #6, merge this for a doctype fix and a different, clearer table of contents:
<img width="556" height="824" alt="image" src="https://github.com/user-attachments/assets/0d5ad82c-54d5-47e9-b64d-8304c2bd8c84" />
