### PR TITLE
Redesign header

### DIFF
--- a/docs/header.html
+++ b/docs/header.html
@@ -8,10 +8,6 @@
             --header-height: 4rem;
         }
 
-        * {
-            box-sizing: border-box;
-        }
-
         .site-header {
             display: flex;
             max-width: 1200px;

--- a/docs/header.html
+++ b/docs/header.html
@@ -46,7 +46,7 @@
             }
         }
 
-        nav {
+        .nav-links {
             display: flex;
             a {
                 display: flex;
@@ -88,7 +88,7 @@
                 Home
             </a>
         </h1>
-        <nav>
+        <nav class="nav-links">
             <a href="ocean.html">Ocean</a>
             <a href="docs.html">Docs</a>
             <a href="blog.html">Blog</a>

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,182 +1,129 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>Puffing Up Reinforcement Learning</title>
     <style>
         :root {
-            --header-height: 160px;
+            --header-height: 4rem;
         }
 
-        body {
-            margin: 0;
-            padding: 0;
-            font-family: system-ui, -apple-system, sans-serif;
+        * {
+            box-sizing: border-box;
         }
 
         .site-header {
-            background: var(--bg-color);
-            padding: 1rem 0;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            height: var(--header-height);
-        }
-
-        .header-content {
+            display: flex;
             max-width: 1200px;
+            height: var(--header-height);
             margin: 0 auto;
-            padding: 0 2rem;
-            height: 100%;
         }
 
-        .header-main {
+        .title {
             display: grid;
-            grid-template-columns: 2fr 1fr;
-            height: 100%;
-            gap: 2rem;
+            font-size: inherit;
+            font-weight: inherit;
+            color: inherit;
+            margin: 0;
+            flex-grow: 1;
+            a {
+                display: flex;
+                gap: 0.5rem;
+                padding-right: 0.5rem;
+                align-items: center;
+            }
+            a:not(:hover) {
+                color: inherit;
+            }
+            video {
+                height: 2rem;
+            }
+            .text {
+                font-weight: bold;
+            }
+            .spacer {
+                flex-grow: 1;
+            }
         }
 
-        .left-content {
+        nav {
             display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            gap: 1rem;
-            height: 100%;
-        }
-
-        .logo {
-            font-size: 2rem;
-            font-weight: bold;
-            color: var(--text-color);
-            text-decoration: none;
-        }
-
-        .nav-links {
-            display: flex;
-            gap: 2rem;
-            align-items: center;
-        }
-
-        .nav-links a {
-            color: var(--text-color);
-            text-decoration: none;
-            font-size: 1.1rem;
-            transition: color 0.2s;
-        }
-
-        .nav-links a:hover {
-            color: var(--highlight);
+            a {
+                display: flex;
+                align-items: center;
+                text-decoration: none;
+                padding: 0 0.5rem;
+            }
+            a:not(:hover) {
+                color: inherit;
+            }
         }
 
         .social-links {
             display: flex;
-            gap: 1rem;
-            align-items: center;
-        }
-
-        .social-links img {
-            height: 20px;
-        }
-
-        .header-video {
-            height: 100%;
-            width: 100%;
-            position: relative;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .header-video video {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-        }
-
-        /* Banner video below header */
-        .banner-video {
-            width: 100%;
-            height: 400px;
-            overflow: hidden;
-            border-radius: 8px;
-            margin-top: 2rem;
-        }
-
-        .banner-video video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
-
-        /* Responsive Design */
-        @media (max-width: 768px) {
-            .header-main {
-                grid-template-columns: 1fr;
-                gap: 1rem;
+            a {
+                display: flex;
+                align-items: center;
+                padding: 0 0.5rem;
+                &:last-child {
+                    padding-right: 0;
+                }
             }
-
-            .nav-links {
-                flex-wrap: wrap;
-                gap: 1rem;
+            img {
+                height: 20px;
             }
-
-            .header-video {
-                display: none; /* Hide puffer on mobile */
-            }
-        .discord-button {
-            display: flex;
-            align-items: center;
-            background-color: #5865F2;
-            color: white;
-            padding: 10px 20px;
-            border-radius: 8px;
-            text-decoration: none;
-            font-family: Arial, sans-serif;
-            font-size: 16px;
-            transition: background-color 0.2s;
-        }
-        .discord-button:hover {
-            background-color: #4752C4;
-        }
-        .discord-button img {
-            width: 24px;
-            height: 24px;
-            margin-right: 8px;
-        }
         }
     </style>
 </head>
 <body>
     <header class="site-header">
-        <div class="header-content">
-            <div class="header-main">
-                <div class="left-content">
-                    <a href="/" class="logo">Puffing Up Reinforcement Learning</a>
-                    <div class="social-links">
-                        <a href="https://github.com/pufferai/pufferlib" target="_blank" rel="noopener noreferrer">
-                            <img src="https://img.shields.io/github/stars/pufferai/pufferlib?labelColor=999999&color=66dcdc&cacheSeconds=100000" alt="GitHub Stars">
-                        </a>
-                        <a href="https://discord.gg/puffer" target="_blank" rel="noopener noreferrer">
-                            <img alt="Discord" src="https://img.shields.io/discord/1019421966429593712?label=Discord&color=5865F2">
-                        </a>
-                        <a href="https://twitter.com/jsuarez5341" target="_blank" rel="noopener noreferrer">
-                            <img src="https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20@jsuarez5341" alt="Twitter Follow">
-                        </a>
-                    </div>
-                    <nav class="nav-links">
-                        <a href="index.html">Home</a>
-                        <a href="ocean.html">Ocean</a>
-                        <a href="docs.html">Docs</a>
-                        <a href="blog.html">Blog</a>
-                    </nav>
-                </div>
-                <div class="header-video">
-                    <video autoplay playsinline muted loop>
-                        <source src="assets/banner.mp4" type="video/mp4">
-                        <source src="assets/banner.webm" type="video/webm">
-                    </video>
-                </div>
-            </div>
+        <h1 class="title">
+            <a href="/">
+                <video autoplay playsinline muted loop>
+                    <source src="assets/banner.mp4" type="video/mp4" />
+                    <source src="assets/banner.webm" type="video/webm" />
+                </video>
+                <span class="text">Puffing Up Reinforcement Learning</span>
+                <div class="spacer"></div>
+                Home
+            </a>
+        </h1>
+        <nav>
+            <a href="ocean.html">Ocean</a>
+            <a href="docs.html">Docs</a>
+            <a href="blog.html">Blog</a>
+        </nav>
+        <div class="social-links">
+            <a
+                href="https://github.com/pufferai/pufferlib"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <img
+                    src="https://img.shields.io/github/stars/pufferai/pufferlib?labelColor=999999&color=66dcdc&cacheSeconds=100000"
+                    alt="GitHub Stars"
+                />
+            </a>
+            <a
+                href="https://discord.gg/puffer"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <img
+                    alt="Discord"
+                    src="https://img.shields.io/discord/1019421966429593712?label=Discord&color=5865F2"
+                />
+            </a>
+            <a
+                href="https://twitter.com/jsuarez5341"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <img
+                    src="https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20@jsuarez5341"
+                    alt="Twitter Follow"
+                />
+            </a>
         </div>
     </header>
 </body>

--- a/docs/header.html
+++ b/docs/header.html
@@ -4,20 +4,38 @@
     <meta charset="UTF-8" />
     <title>Puffing Up Reinforcement Learning</title>
     <style>
-        :root {
-            --header-height: 4rem;
-        }
-
         .site-header {
             display: flex;
-            max-width: 1200px;
-            height: var(--header-height);
-            margin: 0 auto;
-            
+            max-width: var(--content-max-width);
+            margin-inline: auto;
+            box-sizing: border-box;
+
             background-color: var(--foreground);
-            position: sticky;
-            top: 0;
-            z-index: 10;
+            > * {
+                height: var(--header-height);
+            }
+
+            @media (width < 62rem) {
+                flex-direction: column;
+                > :not(.title) {
+                    padding-inline: var(--content-padding);
+                }
+                > .title > a {
+                    padding-inline: var(--content-padding);
+                }
+            }
+            @media (width >= 62rem) {
+                position: sticky;
+                top: 0;
+                z-index: 10;
+
+                > .title > a {
+                    padding-inline-start: var(--content-padding);
+                }
+                > :last-child {
+                    padding-inline-end: var(--content-padding);
+                }
+            }
         }
 
         .title {

--- a/docs/header.html
+++ b/docs/header.html
@@ -17,6 +17,11 @@
             max-width: 1200px;
             height: var(--header-height);
             margin: 0 auto;
+            
+            background-color: var(--foreground);
+            position: sticky;
+            top: 0;
+            z-index: 10;
         }
 
         .title {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -11,7 +11,7 @@
 body {
     margin: 0;
     padding: 0;
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: system-ui, -apple-system, sans-serif;
     background: var(--foreground);
     color: var(--text);
     min-height: 100vh;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -5,7 +5,7 @@
     --text: #f1f1f1;
     --content-max-width: 1280px;
     --content-padding: 40px;
-    --header-height: 180px;
+    --header-height: 4rem;
 }
 
 body {


### PR DESCRIPTION
Of course redesigning anything is a big change, so let me justify this:
- The current header has a lot of dead code (eg styling for the nonexistent `discord-button` and `banner-video`) and out of scope code (eg styling for `body` that should go with the rest of the styles).
- The current header takes up a lot of space (192px to be exact, the same as 7.5 lines of text).
- The current header has some small touch targets (eg dead space between links instead of clickable area).

---

The new header is more compact, inspired by the headers VitePress uses:
<img width="2829" height="115" alt="image" src="https://github.com/user-attachments/assets/5aec3b8e-e534-4994-9c83-bc9bd74d09f9" />
<img width="2829" height="115" alt="image" src="https://github.com/user-attachments/assets/51b368bc-e802-49cf-ac85-05e5e6bf6790" />
Since the new header is compact, it can afford to stick at the top, so I've done that. This removes the need to scroll up to the top every time you need to use the nav.

---

Despite being more compact, it has larger touch targets than the old one:
<img width="2294" height="389" alt="image" src="https://github.com/user-attachments/assets/db0e065a-22ed-4423-b0e7-bae43688dd46" />
vs
<img width="2515" height="159" alt="image" src="https://github.com/user-attachments/assets/c5cd1861-0171-4d60-baa8-86791794fd76" />
Having larger touch targets is helpful to both mobile users (who see everything smaller due to the current lack of `meta name="viewport"` tags) and desktop users (who still have a cursor to maneuver).