### PR TITLE
Make content have a consistent width

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,12 +16,6 @@
             line-height: 1.5;
         }
 
-        .main-content {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: var(--spacing);
-        }
-
         /* Basic content styles */
         .title-content {
             margin-bottom: var(--spacing);
@@ -74,7 +68,7 @@
     </style>
 </head>
 <body>
-    <main class="main-content">
+    <main class="content">
         <div class="title-content">
             <p>PufferLib is a fast and sane reinforcement learning library that can train tiny, super-human models in seconds. The included learning algorithm, hyperparameter tuning, and simulation methods are the product of our own research. All our tools are free and open source. Need a high performance environment for your application? We build them professionally and offer training + extended support. Contact jsuarez🐡puffer🐡ai.</p>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -164,6 +164,7 @@ a:hover {
     max-width: var(--content-max-width);
     margin: 0 auto;
     padding: var(--content-padding);
+    box-sizing: border-box;
 }
 
 /* Reusable image component */


### PR DESCRIPTION
Current behavior:
- home page uses the nonstandard `main-content` class, resulting in a width of 1200px that aligns with the header
- docs pages use the standard `content` class, resulting in a width of 1280px (different from the header's 1200px)

This PR updates all pages to use the `content` class, and updates the `content` class to be 1200px wide (through using `border-box` box sizing).