### PR TITLE
Docs: add native CUDA setup guide (no Docker)

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -113,11 +113,11 @@ torchrun --standalone --nnodes=1 --nproc-per-node=6 -m pufferlib.pufferl train n
 
         <p>Ocean environments are written in C. It's very simple C. Like first 2 weeks of an intro systems course C. Follow this guide and then copy <a href="https://github.com/PufferAI/PufferLib/blob/4.0/ocean/squared">Squared</a> (single-agent) or <a href="https://github.com/PufferAI/PufferLib/blob/4.0/ocean/target">Target</a> (multi-agent) to use as templates for your own environment. Both have detailed comments that walk you through the requirements. Find/replace the demo name with your environment name.</p>
 
-        <p>The .h file contains core environment logic. The .c file contains a standalone demo. Only the .h file is compiled when you run <b>puffer build env_name</b>. The standalone is compiled with <b>puffer build env_name --local</b> or <b>--fast</b> for the optimized build. Observations, actions, rewards, and terminals are each allocated as big chunks of memory that are contiguous across all (usually thousands) of environment instances.</p>
+        <p>The .h file contains core environment logic. The .c file contains a standalone demo. Only the .h file is compiled when you run <b>bash build.sh env_name</b>. The standalone is compiled with <b>puffer build env_name --local</b> or <b>--fast</b> for the optimized build. Observations, actions, rewards, and terminals are each allocated as big chunks of memory that are contiguous across all (usually thousands) of environment instances.</p>
 
         <p>Create a .ini file in the <b>config/</b> directory with the settings for your environment. Copy the one for Squared or Target as a starting point. Your environment is now available for training just like any other Ocean environment:</p>
 
-        <pre><code>puffer build env_name
+        <pre><code>bash build.sh env_name
 puffer train env_name</code></pre>
 
         <p>Use the <b>--local</b> compilation option for testing while writing your environment. It enables address sanitizer and will catch most indexing and overflow bugs. Here's a checklist of common bugs if your env is not training:</p>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -35,7 +35,7 @@ cd puffertank
 
             <h2>UV</h2>
             <pre><code>curl https://raw.githubusercontent.com/PufferAI/PufferTank/refs/heads/4.0/install.sh | sh</code></pre>
-            Requires CUDA. If you don't want to deal with CUDA deps, use the Dockerfile.
+            Requires CUDA 13.0 or higher, see <a href="#post-3">Native CUDA Setup (No Docker)</a> below to get started. If you don't want to deal with CUDA deps, use the Dockerfile.
 
             <h2>Installation Test</h2>
 
@@ -43,6 +43,44 @@ cd puffertank
 puffer train breakout
 puffer eval breakout --load-model-path latest</code></pre>
             Trains a policy. 3-5 seconds on an RTX 5090. Eval requires a graphical interface. Works over ssh -X. Docker over ssh requires -X when you first run the container. Running without -X and reconnecting with -X will not work.
+
+        </article>
+
+        <article id="post-3" class="blog-post">
+            <header class="post-header">
+                <h1>Native CUDA Setup (No Docker)</h1>
+            </header>
+
+            <p>Build the native CUDA backend directly on your host, without the Docker image. The Docker base (<code>nvcr.io/nvidia/cuda:13.0.x-cudnn-devel</code>) bundles three things a bare CUDA toolkit install lacks: the matching toolkit version, NCCL, and cuDNN. Installing those manually is the whole trick. Tested on Ubuntu 24.04 + NVIDIA GeForce RTX 4090. PufferLib 4.0 targets CUDA 13; match that unless you have a reason not to.</p>
+
+            <p><b>1.</b> Confirm <code>nvidia-smi</code> reports a CUDA Version of 13.0 or higher in the top-right (the max toolkit your driver can run).</p>
+            <pre><code>nvidia-smi</code></pre>
+
+            <p><b>2.</b> Add NVIDIA's CUDA apt repo (Ubuntu's default repos lack the toolkit, cuDNN, and a current NCCL). For 22.04, swap <code>ubuntu2404</code> for <code>ubuntu2204</code>.</p>
+            <pre><code>wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update</code></pre>
+
+            <p><b>3.</b> Install the toolkit, NCCL, and cuDNN.</p>
+            <pre><code>sudo apt-get install -y cuda-toolkit-13-0 libnccl2 libnccl-dev cudnn9-cuda-13</code></pre>
+
+            <p><b>4.</b> Point your shell at the toolkit, then re-activate your venv (sourcing <code>~/.bashrc</code> may deactivate it).</p>
+            <pre><code>echo 'export PATH=/usr/local/cuda-13.0/bin:$PATH' >> ~/.bashrc
+echo 'export CUDA_HOME=/usr/local/cuda-13.0' >> ~/.bashrc
+source ~/.bashrc
+source .venv/bin/activate
+nvcc --version   # should report release 13.0</code></pre>
+
+            <p><b>5.</b> Install PyTorch for CUDA 13 and confirm it sees the GPU.</p>
+            <pre><code>uv pip install torch --index-url https://download.pytorch.org/whl/cu130
+python -c "import torch; print(torch.version.cuda, torch.cuda.is_available())"</code></pre>
+
+            <p><b>6.</b> Build and train.</p>
+            <pre><code>bash build.sh breakout
+            puffer train breakout
+            </code></pre>
+
+            <p><b>Troubleshooting.</b> <code>nccl.h: No such file or directory</code> &rarr; NCCL missing, install <code>libnccl2 libnccl-dev</code>. <code>class type not suitable for use with designators</code> &rarr; toolkit older than 13.0, install <code>cuda-toolkit-13-0</code> and repoint <code>PATH</code>/<code>CUDA_HOME</code>. <code>/usr/bin/ld: cannot find -lcudnn</code> &rarr; cuDNN missing, install <code>cudnn9-cuda-13</code>. If <code>-lcudnn</code> is still missing after install, run <code>export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH && sudo ldconfig</code>. If <code>torch.cuda.is_available()</code> is <code>False</code> or reports the wrong CUDA, reinstall torch with <code>--index-url https://download.pytorch.org/whl/cu130</code>.</p>
 
         </article>
 

--- a/install_cuda_native.sh
+++ b/install_cuda_native.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Native CUDA setup for PufferLib (no Docker), Ubuntu 24.04 + NVIDIA GPU.
+# Installs the CUDA 13 toolkit, NCCL, and cuDNN — the three things the
+# PufferTank Docker base image bundles that a standard toolkit install lacks.
+# This was tested on Ubuntu 24.04 + NVIDIA GeForce RTX 4090.
+#
+# Usage:  bash install_cuda_native.sh
+# Run from your PufferLib checkout with your venv already activated.
+
+set -euo pipefail
+
+CUDA_VER="13.0"
+UBUNTU_REPO="ubuntu2404"   # change to ubuntu2204 for 22.04
+
+echo "==> Checking for nvidia-smi"
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "ERROR: nvidia-smi not found. Install your NVIDIA driver first." >&2
+  exit 1
+fi
+nvidia-smi | head -n 4
+echo "    Confirm the 'CUDA Version' above is >= ${CUDA_VER} before continuing."
+
+echo "==> Adding NVIDIA CUDA apt repo"
+KEYRING_DEB="cuda-keyring_1.1-1_all.deb"
+wget -q "https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_REPO}/x86_64/${KEYRING_DEB}"
+sudo dpkg -i "${KEYRING_DEB}"
+rm -f "${KEYRING_DEB}"
+sudo apt-get update
+
+echo "==> Installing CUDA toolkit, NCCL, and cuDNN"
+sudo apt-get install -y \
+  "cuda-toolkit-${CUDA_VER/./-}" \
+  libnccl2 libnccl-dev \
+  "cudnn9-cuda-${CUDA_VER%%.*}"
+
+echo "==> Configuring PATH/CUDA_HOME in ~/.bashrc"
+CUDA_PATH_LINE="export PATH=/usr/local/cuda-${CUDA_VER}/bin:\$PATH"
+CUDA_HOME_LINE="export CUDA_HOME=/usr/local/cuda-${CUDA_VER}"
+grep -qxF "${CUDA_PATH_LINE}" ~/.bashrc || echo "${CUDA_PATH_LINE}" >> ~/.bashrc
+grep -qxF "${CUDA_HOME_LINE}" ~/.bashrc || echo "${CUDA_HOME_LINE}" >> ~/.bashrc
+
+# Apply to the current shell too (don't source ~/.bashrc; it may deactivate the venv).
+export PATH="/usr/local/cuda-${CUDA_VER}/bin:$PATH"
+export CUDA_HOME="/usr/local/cuda-${CUDA_VER}"
+
+echo "==> nvcc version:"
+nvcc --version | grep release || true
+
+echo "==> Installing PyTorch for CUDA ${CUDA_VER}"
+CU_TAG="cu${CUDA_VER//./}"
+uv pip install torch --index-url "https://download.pytorch.org/whl/${CU_TAG}"
+
+echo "==> Verifying torch sees the GPU:"
+python -c "import torch; print('torch', torch.__version__, 'cuda', torch.version.cuda, 'available', torch.cuda.is_available())"
+
+echo
+echo "Done. Now build and train:"
+echo "    bash build.sh breakout"
+echo "    puffer train breakout"


### PR DESCRIPTION
# PufferLib: Native CUDA Setup (No Docker)

This PR adds some guidance for building PufferLib's native CUDA backend for people who prefer this over using the Docker image. Largely based on the existing Docker base (`nvcr.io/nvidia/cuda:13.0.x-cudnn-devel`), which bundles the matching toolkit version, NCCL, and cuDNN.

---

> Note: Tested on **Ubuntu 24.04 + NVIDIA GeForce RTX 4090**. PufferLib 4.0 targets
**CUDA 13**; match that unless you have a reason not to.

---

-> Adding the steps that worked for me as a reference, the PR integrates these in the docs + adds a bash script.


## Steps

**1. Check your driver supports CUDA >= 13.0** — the "CUDA Version" shown
top-right by `nvidia-smi` is the max toolkit your driver can run.

```bash
nvidia-smi
```

**2. Add NVIDIA's CUDA apt repo** (Ubuntu's default repos lack the toolkit,
cuDNN, and a current NCCL). For 22.04, swap `ubuntu2404` -> `ubuntu2204`.

```bash
wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
sudo dpkg -i cuda-keyring_1.1-1_all.deb
sudo apt-get update
```

**3. Install the toolkit, NCCL, and cuDNN.**

```bash
sudo apt-get install -y cuda-toolkit-13-0 libnccl2 libnccl-dev cudnn9-cuda-13
```

**4. Point your shell at the toolkit**, then re-activate your venv (sourcing
`~/.bashrc` may deactivate it).

```bash
echo 'export PATH=/usr/local/cuda-13.0/bin:$PATH' >> ~/.bashrc
echo 'export CUDA_HOME=/usr/local/cuda-13.0' >> ~/.bashrc
source ~/.bashrc
source .venv/bin/activate
nvcc --version   # should report release 13.0
```

**5. Install PyTorch for CUDA 13** and confirm it sees the GPU.

```bash
uv pip install torch --index-url https://download.pytorch.org/whl/cu130
python -c "import torch; print(torch.version.cuda, torch.cuda.is_available())"
```

**6. Build and train.**

```bash
bash build.sh breakout
>>>
Compiling static library for breakout...
Compiling CUDA (native) training backend...
Built: pufferlib/_C.cpython-312-x86_64-linux-gnu.so
```


```
puffer train breakout

>>>
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│  PufferLib 4.0   🐡                                                                                 GPU: 95%                                   VRAM: 1.7/23G                                              RAM: 1.0G  │
│                                                                                                                                                                                                                      │
│  Summary                                                       Value    Evaluate                                         353ms            59%    Losses                                                       Value  │
│  Env                                                        breakout      GPU                                            157ms            26%    policy                                                       0.004  │
│  Params                                                        32.4K      Env                                            136ms            22%    value                                                        0.048  │
│  Steps                                                         87.0M    Train                                            243ms            40%    entropy                                                      0.164  │
│  SPS                                                           17.8M      Misc                                            34ms             5%    total                                                        0.063  │
│  Epoch                                                           332      Forward                                        209ms            35%    old_kl                                                       0.005  │
│  Uptime                                                  0d 0h 0m 4s                                                                             kl                                                           0.005  │
│  Remaining                                                     392ms                                                                             clipfrac                                                     0.003  │
│                                                                                                                                                                                                                      │
│  User Stats                                                                                        Value    User Stats                                                                                        Value  │
│  perf                                                                                              0.939    score                                                                                           811.252  │
│  episode_return                                                                                  811.252    episode_length                                                                                16165.714  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```